### PR TITLE
revert ldap3 upgrade to 2.5.1 pending cannatag/ldap3#636

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ dnspython==1.16.0
 idna==2.8
 Jinja2==2.10
 kombu==4.2.2.post1
-ldap3==2.5.2
+ldap3==2.5.1
 MarkupSafe==1.1.0
 ocflib
 pexpect==4.6.0


### PR DESCRIPTION
As discussed in cannatag/ldap3#636, the published source tarball for ldap3 v2.5.2 on PyPI has one file that is incorrectly empty. This PR reverts ldap3 to 2.5.1 in the meantime.

I'm not sure this is the right solution. I built a .deb off this branch and installed it on supernova, and it seems to work now, so we might want to just avoid updating supernova until the upstream issue is fixed. Hopefully this will be within the week.