### PR TITLE
Migrate from autopep8-wrapper to mirrors-autopep8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
+repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks.git
-    sha: v0.9.5
+    rev: v2.1.0
     hooks:
-    -   id: autopep8-wrapper
     -   id: check-added-large-files
     -   id: check-docstring-first
     -   id: check-executables-have-shebangs
@@ -20,22 +20,26 @@
     -   id: requirements-txt-fixer
     -   id: sort-simple-yaml
     -   id: trailing-whitespace
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.4.3
+    hooks:
+    -   id: autopep8
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: '3.7.3'
+    rev: 3.7.7
     hooks:
     - id: flake8
       language_version: python3.5
 -   repo: https://github.com/asottile/reorder_python_imports.git
-    sha: v0.3.5
+    rev: v1.4.0
     hooks:
     -   id: reorder-python-imports
 -   repo: https://github.com/FalconSocial/pre-commit-mirrors-pep257.git
-    sha: f464d46624a959c6969ce6bcf2cd531cdeefb85a
+    rev: v0.3.3
     hooks:
     -   id: pep257
         exclude: (^setup\.py|__init__\.py)$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks.git
-    sha: v1.1.4
+    rev: v1.1.6
     hooks:
     -   id: remove-tabs
         files: \.py$


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos